### PR TITLE
Prevent too early execution of objdump

### DIFF
--- a/template/Makefile.posix
+++ b/template/Makefile.posix
@@ -1,7 +1,7 @@
 TOOLCHAIN_PATH ?= $(HOME)/Nedlastinger/gcc-arm-none-eabi-4_7-2013q3/bin/
 TERMINAL ?= gnome-terminal -e
 
-FLASH_START_ADDRESS := $(shell $(OBJDUMP) -h $(ELF) -j .text | grep .text | awk '{print $$4}')
+FLASH_START_ADDRESS = $(shell $(OBJDUMP) -h $(ELF) -j .text | grep .text | awk '{print $$4}')
 
 ifdef SEGGER_SERIAL
 JLINKEXE_OPTION = -SelectEmuBySn $(SEGGER_SERIAL)


### PR DESCRIPTION
Whithout this change, objdump will be also executed e.g. when performing »make clean«.
