### PR TITLE
tweak SOURCE_PATHS and SDK_INCLUDE_PATH to build against the 5.2.1 API s...

### DIFF
--- a/template/Makefile
+++ b/template/Makefile
@@ -38,7 +38,9 @@ endif
 ifdef USE_BLE
     LIBRARY_PATHS += $(SDK_INCLUDE_PATH)ble/
     LIBRARY_PATHS += $(SDK_INCLUDE_PATH)ble/ble_services/
-    SOURCE_PATHS += $(SDK_SOURCE_PATH)ble/ble_services/
+    SOURCE_PATHS += $(wildcard $(SDK_SOURCE_PATH)/ble/*/)
+    SDK_INCLUDE_PATH += $(SDK_PATH)Include/ble/
+    SDK_INCLUDE_PATH += $(SDK_PATH)Include/ble/ble_services/
     CFLAGS += -DBLE_STACK_SUPPORT_REQD
 endif
 
@@ -47,6 +49,9 @@ ifdef USE_ANT
 endif
 
 ifdef USE_SOFTDEVICE
+    SDK_INCLUDE_PATH += $(SDK_PATH)Include/app_common/
+    SDK_INCLUDE_PATH += $(SDK_PATH)Include/sd_common/
+    SDK_INCLUDE_PATH += $(SDK_PATH)Include/$(USE_SOFTDEVICE)
     LIBRARY_PATHS += $(SDK_INCLUDE_PATH)$(USE_SOFTDEVICE)
     LIBRARY_PATHS += $(SDK_INCLUDE_PATH)app_common/
     LIBRARY_PATHS += $(SDK_INCLUDE_PATH)sd_common/


### PR DESCRIPTION
I think that this is the minimal set of changes required to the template to build against the 5.2.1 API source. I'm able to build the BLE proximity and beacon examples, and with some tweaking in the example's pure_gcc/Makefile to include the ADC driver, I should be able to have hrs working as well.
