### PR TITLE
the s110 version7 softdevice has a different memory layout

### DIFF
--- a/template/gcc_nrf51_s120v7.ld
+++ b/template/gcc_nrf51_s120v7.ld
@@ -1,0 +1,13 @@
+/* Linker script to configure memory regions. */
+
+SEARCH_DIR(.)
+GROUP(-lgcc -lc -lnosys)
+
+MEMORY
+{
+  FLASH (rx) : ORIGIN = 0x00016000, LENGTH = 0x2A000 
+  RAM (rwx) :  ORIGIN = 0x20002000, LENGTH = 0x2000 
+}
+
+
+INCLUDE "gcc_nrf51_common.ld"


### PR DESCRIPTION
LINKER_SCRIPT=gcc_nrf51_s120v7.ld

in your projects makefile will build the app hex with the proper memory layout for s110 version 7.0.0
