### PR TITLE
Update gcc_nrf51_s110.ld

### DIFF
--- a/template/gcc_nrf51_s110.ld
+++ b/template/gcc_nrf51_s110.ld
@@ -1,7 +1,7 @@
 /* Linker script to configure memory regions. */
 MEMORY
 {
-  FLASH (rx) : ORIGIN = 0x15000, LENGTH = 0x2B000 /* 84 kB is taken by S110, 172 kB for app. */
+  FLASH (rx) : ORIGIN = 0x16000, LENGTH = 0x2A000 /* 88 kB is taken by S110, 168 kB for app. */
   RAM (rwx) : ORIGIN = 0x20002000, LENGTH = 0x2000 /* 8 kB is taken by S110,8 kB for app. */
 }
 INCLUDE "gcc_nrf51_common.ld"


### PR DESCRIPTION
I believe this is the new size for the 7.0.0 s110 softdevice.
