### PR TITLE
uses Makefile.local to override machine-specific settings

### DIFF
--- a/examples/pca10001/blinky_example/pure-gcc/Makefile
+++ b/examples/pca10001/blinky_example/pure-gcc/Makefile
@@ -1,3 +1,6 @@
+# pull in any machine-local overrides
+-include Makefile.local
+
 # List all source files the application uses.
 APPLICATION_SRCS = $(notdir $(wildcard ../*.c))  nrf_delay.c
 # Use shell to find name of root folder. Possible but horrible to do in make.
@@ -9,8 +12,8 @@ BOARD = BOARD_PCA10001
 
 #USE_SOFTDEVICE = s110
 
-SDK_PATH = $(HOME)/Projects/nrf51/nrf51822/
-TEMPLATE_PATH = $(HOME)/Projects/nrf51-pure-gcc-setup/template/
+SDK_PATH ?= $(HOME)/Projects/nrf51/nrf51822/
+TEMPLATE_PATH ?= $(HOME)/Projects/nrf51-pure-gcc-setup/template/
 
 CFLAGS = -Os
 

--- a/examples/pca10001/s110/ble_app_hrs/pure-gcc/Makefile
+++ b/examples/pca10001/s110/ble_app_hrs/pure-gcc/Makefile
@@ -1,3 +1,6 @@
+# pull in any machine-local overrides
+-include Makefile.local
+
 # List all source files the application uses.
 APPLICATION_SRCS = $(notdir $(wildcard ../*.c))
 APPLICATION_SRCS += app_gpiote.c
@@ -23,8 +26,8 @@ BOARD = BOARD_PCA10001
 
 USE_SOFTDEVICE = s110
 
-SDK_PATH = $(HOME)/Projects/nrf51-sdk-6.0.0/nrf51822/
-TEMPLATE_PATH = $(HOME)/Projects/nrf51-pure-gcc-setup/template/
+SDK_PATH ?= $(HOME)/Projects/nrf51-sdk-6.0.0/nrf51822/
+TEMPLATE_PATH ?= $(HOME)/Projects/nrf51-pure-gcc-setup/template/
 
 CFLAGS = -Os
 

--- a/examples/pca10001/s110/ble_app_proximity/pure-gcc/Makefile
+++ b/examples/pca10001/s110/ble_app_proximity/pure-gcc/Makefile
@@ -1,3 +1,6 @@
+# pull in any machine-local overrides
+-include Makefile.local
+
 # List all source files the application uses.
 APPLICATION_SRCS = $(notdir $(wildcard ../*.c))
 APPLICATION_SRCS += app_gpiote.c
@@ -26,8 +29,8 @@ BOARD = BOARD_PCA10001
 
 USE_SOFTDEVICE = s110
 
-SDK_PATH = ../../../../../
-TEMPLATE_PATH = c:/temp/nrf51-pure-gcc-setup/template/
+SDK_PATH ?= ../../../../../
+TEMPLATE_PATH ?= c:/temp/nrf51-pure-gcc-setup/template/
 
 CFLAGS = -Os
 


### PR DESCRIPTION
Often you want to build the same project on different machines, possibly with
different developers. These machines often have different paths for the SDK,
toolchain, etc. This PR adds a line to the example Makefiles that includes from
Makefile.local to allow easier overriding.
